### PR TITLE
Support SSH remote.origin.url

### DIFF
--- a/OpenOnGitHub/GitAnalysis.cs
+++ b/OpenOnGitHub/GitAnalysis.cs
@@ -56,6 +56,10 @@ namespace OpenOnGitHub
                 ? originUrl.Value.Substring(0, originUrl.Value.Length - 4) // remove .git
                 : originUrl.Value;
 
+            // git@github.com:user/repo -> http://github.com/user/repo
+            if (urlRoot.StartsWith("git@", StringComparison.InvariantCultureIgnoreCase))
+                urlRoot = "http://" + urlRoot.Substring(4).Replace(":", "/");
+
             // https://user@github.com/user/repo -> https://github.com/user/repo
             urlRoot = Regex.Replace(urlRoot, "(?<=^https?://)([^@/]+)@", "");
 

--- a/OpenOnGitHub/GitAnalysis.cs
+++ b/OpenOnGitHub/GitAnalysis.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 
 namespace OpenOnGitHub
@@ -71,7 +72,7 @@ namespace OpenOnGitHub
                                     : string.Format("#L{0}-{1}", selectionLineRange.Item1, selectionLineRange.Item2)
                                 : "";
 
-            var fileUrl = string.Format("{0}/blob/{1}/{2}{3}", urlRoot.Trim('/'), repositoryTarget.Trim('/'), fileIndexPath.Trim('/'), fragment);
+            var fileUrl = string.Format("{0}/blob/{1}/{2}{3}", urlRoot.Trim('/'), WebUtility.UrlEncode(repositoryTarget.Trim('/')), fileIndexPath.Trim('/'), fragment);
             return fileUrl;
         }
 

--- a/OpenOnGitHub/GitAnalysis.cs
+++ b/OpenOnGitHub/GitAnalysis.cs
@@ -57,8 +57,7 @@ namespace OpenOnGitHub
                 : originUrl.Value;
 
             // git@github.com:user/repo -> http://github.com/user/repo
-            if (urlRoot.StartsWith("git@", StringComparison.InvariantCultureIgnoreCase))
-                urlRoot = "http://" + urlRoot.Substring(4).Replace(":", "/");
+            urlRoot = Regex.Replace(urlRoot, "^git@(.+):(.+)/(.+)$", match => "http://" + string.Join("/", match.Groups.OfType<Group>().Skip(1).Select(group => group.Value)), RegexOptions.IgnoreCase);
 
             // https://user@github.com/user/repo -> https://github.com/user/repo
             urlRoot = Regex.Replace(urlRoot, "(?<=^https?://)([^@/]+)@", "");


### PR DESCRIPTION
#### Support SSH URL

Can't open the source code, when the `remote.origin.url` is SSH URL.
#### Encode branch name

Can't open the source code, when the branch name contains `#` char.
