### PR TITLE
Humanize menu command titles

### DIFF
--- a/OpenOnGitHub/Constants.cs
+++ b/OpenOnGitHub/Constants.cs
@@ -15,6 +15,7 @@ namespace OpenOnGitHub
         public const uint OpenMaster = 0x100;
         public const uint OpenBranch = 0x200;
         public const uint OpenRevision = 0x300;
+        public const uint OpenRevisionFull = 0x400;
     };
 
     static class PackageVersion

--- a/OpenOnGitHub/GitAnalysis.cs
+++ b/OpenOnGitHub/GitAnalysis.cs
@@ -45,6 +45,20 @@ namespace OpenOnGitHub
             }
         }
 
+        public string GetGitHubTargetDescription(GitHubUrlType urlType)
+        {
+            switch (urlType)
+            {
+                case GitHubUrlType.CurrentBranch:
+                    return "Branch: " + repository.Head.Name.Replace("origin/", "");
+                case GitHubUrlType.CurrentRevision:
+                    return "Revision: " + repository.Commits.First().Id.ToString(8);
+                case GitHubUrlType.Master:
+                default:
+                    return "master";
+            }
+        }
+
         public string BuildGitHubUrl(GitHubUrlType urlType, Tuple<int, int> selectionLineRange)
         {
             // https://github.com/user/repo.git

--- a/OpenOnGitHub/GitAnalysis.cs
+++ b/OpenOnGitHub/GitAnalysis.cs
@@ -38,7 +38,7 @@ namespace OpenOnGitHub
                 case GitHubUrlType.CurrentBranch:
                     return repository.Head.Name.Replace("origin/", "");
                 case GitHubUrlType.CurrentRevision:
-                    return repository.Commits.First().Id.Sha;
+                    return repository.Commits.First().Id.ToString(8);
                 case GitHubUrlType.Master:
                 default:
                     return "master";

--- a/OpenOnGitHub/GitAnalysis.cs
+++ b/OpenOnGitHub/GitAnalysis.cs
@@ -11,7 +11,8 @@ namespace OpenOnGitHub
     {
         Master,
         CurrentBranch,
-        CurrentRevision
+        CurrentRevision,
+        CurrentRevisionFull
     }
 
     public sealed class GitAnalysis : IDisposable
@@ -39,6 +40,8 @@ namespace OpenOnGitHub
                     return repository.Head.Name.Replace("origin/", "");
                 case GitHubUrlType.CurrentRevision:
                     return repository.Commits.First().Id.ToString(8);
+                case GitHubUrlType.CurrentRevisionFull:
+                    return repository.Commits.First().Id.Sha;
                 case GitHubUrlType.Master:
                 default:
                     return "master";
@@ -53,6 +56,8 @@ namespace OpenOnGitHub
                     return "Branch: " + repository.Head.Name.Replace("origin/", "");
                 case GitHubUrlType.CurrentRevision:
                     return "Revision: " + repository.Commits.First().Id.ToString(8);
+                case GitHubUrlType.CurrentRevisionFull:
+                    return "Revision: " + repository.Commits.First().Id.ToString(8) + "... (Full ID)";
                 case GitHubUrlType.Master:
                 default:
                     return "master";

--- a/OpenOnGitHub/OpenOnGitHub.vsct
+++ b/OpenOnGitHub/OpenOnGitHub.vsct
@@ -45,6 +45,14 @@
                     <CommandName>revision</CommandName>
                 </Strings>
             </Button>
+            <Button guid="guidOpenOnGitHubCmdSet" id="OpenRevisionFull" priority="0x0400" type="Button">
+                <Parent guid="guidOpenOnGitHubCmdSet" id="SubMenuGroup" />
+                <CommandFlag>TextChanges</CommandFlag>
+                <Strings>
+                    <ButtonText>revisionFull</ButtonText>
+                    <CommandName>revisionFull</CommandName>
+                </Strings>
+            </Button>
         </Buttons>
     </Commands>
     <CommandPlacements>
@@ -108,6 +116,7 @@
             <IDSymbol name="OpenMaster" value="0x0100" />
             <IDSymbol name="OpenBranch" value="0x0200" />
             <IDSymbol name="OpenRevision" value="0x0300" />
+            <IDSymbol name="OpenRevisionFull" value="0x0400" />
         </GuidSymbol>
 
         <!-- List for various editor types -->

--- a/OpenOnGitHub/OpenOnGitHubPackage.cs
+++ b/OpenOnGitHub/OpenOnGitHubPackage.cs
@@ -39,7 +39,13 @@ namespace OpenOnGitHub
             var mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (mcs != null)
             {
-                foreach (var item in new[] { PackageCommanddIDs.OpenMaster, PackageCommanddIDs.OpenBranch, PackageCommanddIDs.OpenRevision })
+                foreach (var item in new[]
+                {
+                    PackageCommanddIDs.OpenMaster,
+                    PackageCommanddIDs.OpenBranch,
+                    PackageCommanddIDs.OpenRevision,
+                    PackageCommanddIDs.OpenRevisionFull
+                })
                 {
                     var menuCommandID = new CommandID(PackageGuids.guidOpenOnGitHubCmdSet, (int)item);
                     var menuItem = new OleMenuCommand(ExecuteCommand, menuCommandID);
@@ -151,6 +157,7 @@ namespace OpenOnGitHub
             if (commandId == PackageCommanddIDs.OpenMaster) return GitHubUrlType.Master;
             if (commandId == PackageCommanddIDs.OpenBranch) return GitHubUrlType.CurrentBranch;
             if (commandId == PackageCommanddIDs.OpenRevision) return GitHubUrlType.CurrentRevision;
+            if (commandId == PackageCommanddIDs.OpenRevisionFull) return GitHubUrlType.CurrentRevisionFull;
             else return GitHubUrlType.Master;
         }
     }

--- a/OpenOnGitHub/OpenOnGitHubPackage.cs
+++ b/OpenOnGitHub/OpenOnGitHubPackage.cs
@@ -71,7 +71,7 @@ namespace OpenOnGitHub
                     }
                     else
                     {
-                        command.Text = targetPath;
+                        command.Text = git.GetGitHubTargetDescription(type);
                         command.Enabled = true;
                     }
                 }


### PR DESCRIPTION
Humanize menu command titles; it's too long, and hard to select.
- **before:**
  - master
  - hogeBranch
  - ffffffffffffffffffffffffffffffffffffffff
- **after:**
  - master
  - Branch: hogeBranch
  - Revision: ffffffff
  - Revision: ffffffff.... (Full ID)

New command is added to open current revision with full commit ID URI.

Tested, and it seems to work fine.
