### PR TITLE
Closes issue #18 - Support for enterprise gitHub

### DIFF
--- a/OpenOnGitHub/Constants.cs
+++ b/OpenOnGitHub/Constants.cs
@@ -39,6 +39,6 @@ namespace OpenOnGitHub
 
     static class PackageVersion
     {
-        public const string Version = "2.0.3";
+        public const string Version = "2.0.4";
     }
 }

--- a/OpenOnGitHub/OpenOnGitHubPackage.cs
+++ b/OpenOnGitHub/OpenOnGitHubPackage.cs
@@ -140,28 +140,24 @@ namespace OpenOnGitHub
                 ? urlDomainParts[urlDomainParts.Length - 2] + "." + urlDomainParts[urlDomainParts.Length - 1]
                 : host;
 
-            if (!UrlProviders.TryGetValue(domain, out var provider))
+            if (UrlProviders.TryGetValue(domain, out var provider))
             {
-                // private server url such like https://tfs.contoso.com:8080/tfs/Project.
-                if (repositoryUri.Port == 8080
-                    && repositoryUri.Segments.Length >= 5
-                    && string.Equals(repositoryUri.Segments[1], "tfs/", StringComparison.Ordinal))
-                {
-                    provider = AzureDevOpsUrlProvider;
-                }
-                // https://gitlab.contoso.com
-                else if (urlDomainParts[0] == "gitlab")
-                {
-                    provider = GitHubLabUrlProvider;
-                }
+                return provider;
             }
 
-            if (provider == null)
+            // Private server url such like https://tfs.contoso.com:8080/tfs/Project.
+            if (repositoryUri.Port == 8080
+                && repositoryUri.Segments.Length >= 5
+                && string.Equals(repositoryUri.Segments[1], "tfs/", StringComparison.Ordinal))
             {
-                throw new InvalidOperationException($"Unknown repository provider: {repositoryUri}");
+                return AzureDevOpsUrlProvider;
             }
 
-            return provider;
+            // Fallback to Git(Hub|Lab) provider as default
+            // https://gitlab.contoso.com
+            // https://{Self-Managed}/{org or user}/{repo name}
+
+            return GitHubLabUrlProvider;
         }
 
         private void ExecuteCommand(object sender, EventArgs e)

--- a/OpenOnGitHub/source.extension.vsixmanifest
+++ b/OpenOnGitHub/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="465b40b6-311a-4e37-9556-95fced2de9c6" Version="2.0.3" Language="en-US" Publisher="neuecc, ycherkes" />
+        <Identity Id="465b40b6-311a-4e37-9556-95fced2de9c6" Version="2.0.4" Language="en-US" Publisher="neuecc, ycherkes" />
         <DisplayName>Open on GitHub</DisplayName>
         <Description xml:space="preserve">Extension for opening files on GitHub, GitLab, Gitea, Bitbucket and AzureDevOps (dev.azure.com, visualstudio.com, tfs)</Description>
         <MoreInfo>https://github.com/neuecc/Open-on-GitHub</MoreInfo>

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Right click on editor, if repository is hosted on GitHub, you can jump to master
 
 Install
 ---
-Download from [Visual Studio Gallery - Open on GitHub](https://visualstudiogallery.msdn.microsoft.com/79bf2ea3-9e78-4212-b22f-cdcdd75e791d)
+Download from [Visual Studio Gallery - Open on GitHub](https://marketplace.visualstudio.com/items?itemName=neuecc.OpenonGitHub)


### PR DESCRIPTION
1. Use GitHubLabUrlProvider as a fallback provider.
2. Fix the extension URL.

Compiled package for testing: 
[OpenOnGitHub.zip](https://github.com/neuecc/Open-on-GitHub/files/13256180/OpenOnGitHub.zip)
