### PR TITLE
Add Support for develop as a Default Branch

### DIFF
--- a/OpenOnGitHub/GitRepository.cs
+++ b/OpenOnGitHub/GitRepository.cs
@@ -52,7 +52,7 @@ namespace OpenOnGitHub
             _rootDirectory = _innerRepository.Info.WorkingDirectory;
 
             MainBranchName = _innerRepository.Branches.Select(x => x.FriendlyName)
-                .FirstOrDefault(x => new[] { "main", "master" }.Contains(x.ToLower())) ?? "main";
+                .FirstOrDefault(x => new[] { "main", "master", "develop" }.Contains(x.ToLower())) ?? "main";
         }
 
         public bool IsInsideRepositoryFolder(string filePath)


### PR DESCRIPTION
I've been working on repositories where the default branch is `develop`, and there is no `main` or `master` branch. I noticed that the current implementation of [Open-on-GitHub](https://github.com/neuecc/Open-on-GitHub) does not support this configuration.

I understand that [libgit2sharp](https://github.com/libgit2/libgit2sharp), which Open-on-GitHub uses, does not yet support extracting the default remote branch. There is an open PR for this feature here: https://github.com/libgit2/libgit2sharp/pull/1969.

In the meantime, I propose adding `develop` as the last possible default branch when neither `main` nor `master` has been matched.