### PR TITLE
Fix the SourceLink issue when the Visual Studio has no Symbol cache directory setting specified

### DIFF
--- a/OpenOnGitHub/SourceLinkInternals/VisualStudioSourceLinkHelper.cs
+++ b/OpenOnGitHub/SourceLinkInternals/VisualStudioSourceLinkHelper.cs
@@ -43,7 +43,7 @@ internal sealed class VisualStudioSourceLinkHelper(IVsDebuggerSymbolSettingsMana
 
         var pdbFilePath = Path.Combine(Path.GetDirectoryName(dllFullName) ?? "", pdbFileName);
 
-        // Ms has changed the default value of Tools > Options -> Debugging > Symbols.
+        // Ms has changed the default value of Tools > Options -> Debugging > Symbols -> Symbol cache directory.
         // Now it's empty by default, so check some default paths and then fallback to the dll path.
         if (!File.Exists(pdbFilePath))
         {

--- a/OpenOnGitHub/source.extension.vsixmanifest
+++ b/OpenOnGitHub/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="465b40b6-311a-4e37-9556-95fced2de9c6" Version="2.1.0" Language="en-US" Publisher="neuecc, ycherkes" />
+        <Identity Id="465b40b6-311a-4e37-9556-95fced2de9c6" Version="2.1.1" Language="en-US" Publisher="neuecc, ycherkes" />
         <DisplayName>Open on GitHub</DisplayName>
         <Description xml:space="preserve">Extension for opening files on GitHub, GitLab, Gitea, Bitbucket and AzureDevOps (dev.azure.com, visualstudio.com, tfs)</Description>
         <MoreInfo>https://github.com/neuecc/Open-on-GitHub</MoreInfo>


### PR DESCRIPTION
Fix the SourceLink issue when the Visual Studio has no "Tools > Options -> Debugging > Symbols -> Symbol cache directory" specified by default.

Check "%LocalAppData%\Temp\SymbolCache" and "%LocalAppData%\SymbolSourceSymbols" paths before fall back to dll.
